### PR TITLE
Added .yml at docker compose

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ If you don't have an existing Grafana / Prometheus / Pushgateway setup, you can 
 ### Docker Compose
 
 ```shell
-docker compose -f docker-compose up -d 
+docker compose -f docker-compose.yml up -d 
 ```
 
 Then open up a browser and go to http://localhost:3000/ to open the Grafana UI and use the dashboards.


### PR DESCRIPTION
The docker compose command needs the .yml extension behind `docker-compose.yml` or it will report file not found on both Windows and WSL.